### PR TITLE
Raw giturl

### DIFF
--- a/amp-rnaseq_reprocessing/amp-rnaseq_reprocess-workflow/utils/giturl.py
+++ b/amp-rnaseq_reprocessing/amp-rnaseq_reprocess-workflow/utils/giturl.py
@@ -5,7 +5,7 @@ import git
 import os
 
 
-def github_url(path='.'):
+def github_url(path='.', raw=False):
     repo = git.Repo('.', search_parent_directories=True)
     assert not repo.bare
     # TODO: handle case where the remote is not named 'origin'
@@ -24,6 +24,12 @@ def github_url(path='.'):
     if remote_url.endswith('.git'):
         remote_url = remote_url[:-4]
 
+    blob = 'blob/'
+    if raw:
+        # make it the raw url
+        remote_url = remote_url.replace('github', 'raw.githubusercontent')
+        blob = ''
+
     # path to object relative to repo root
     abs_path = os.path.abspath(path)
     path_from_root = abs_path.replace(repo.working_tree_dir,'')
@@ -31,7 +37,7 @@ def github_url(path='.'):
     # latest commit SHA
     sha = repo.rev_parse('HEAD').hexsha
 
-    return f'{remote_url}/blob/{sha}{path_from_root}'
+    return f'{remote_url}/{blob}{sha}{path_from_root}'
 
 
 def main():
@@ -40,8 +46,12 @@ def main():
         '--path',
         default='.',
         help='Relative path')
+    parser.add_argument(
+        '--raw',
+        action='store_true',
+        help='Optionally generate the url to the raw file')
     args = parser.parse_args()
-    print(github_url(args.path))
+    print(github_url(args.path, args.raw))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Altered giturl utility to produce "raw" urls, optionally.

Examples:
`utils/giturl.py` with no path specified will produce the browsable url to the current directory: https://github.com/Sage-Bionetworks/amp-workflows/blob/618b5373059fb0796ec4e6dd06f8279d7058804d/amp-rnaseq_reprocessing/amp-rnaseq_reprocess-workflow

`utils/giturl.py --raw --path jobs/test-main-paired/job.json` will produce the "raw" url to a file: https://raw.githubusercontent.com/Sage-Bionetworks/amp-workflows/56e24f449a09e4bd402f93f7206eb449ed5de045/amp-rnaseq_reprocessing/amp-rnaseq_reprocess-workflow/jobs/test-main-paired/job.json

Note that request the "raw" url to a folder will create an invalid link.